### PR TITLE
Removed extra code which adds a lot of boilerplate

### DIFF
--- a/step-00/pubspec.yaml
+++ b/step-00/pubspec.yaml
@@ -33,41 +33,4 @@ dev_dependencies:
 
 flutter:
   assets:
-    - packages/shrine_images/0-0.jpg
-    - packages/shrine_images/1-0.jpg
-    - packages/shrine_images/2-0.jpg
-    - packages/shrine_images/3-0.jpg
-    - packages/shrine_images/4-0.jpg
-    - packages/shrine_images/5-0.jpg
-    - packages/shrine_images/6-0.jpg
-    - packages/shrine_images/7-0.jpg
-    - packages/shrine_images/8-0.jpg
-    - packages/shrine_images/9-0.jpg
-    - packages/shrine_images/10-0.jpg
-    - packages/shrine_images/11-0.jpg
-    - packages/shrine_images/12-0.jpg
-    - packages/shrine_images/13-0.jpg
-    - packages/shrine_images/14-0.jpg
-    - packages/shrine_images/15-0.jpg
-    - packages/shrine_images/16-0.jpg
-    - packages/shrine_images/17-0.jpg
-    - packages/shrine_images/18-0.jpg
-    - packages/shrine_images/19-0.jpg
-    - packages/shrine_images/20-0.jpg
-    - packages/shrine_images/21-0.jpg
-    - packages/shrine_images/22-0.jpg
-    - packages/shrine_images/23-0.jpg
-    - packages/shrine_images/24-0.jpg
-    - packages/shrine_images/25-0.jpg
-    - packages/shrine_images/26-0.jpg
-    - packages/shrine_images/27-0.jpg
-    - packages/shrine_images/28-0.jpg
-    - packages/shrine_images/29-0.jpg
-    - packages/shrine_images/30-0.jpg
-    - packages/shrine_images/31-0.jpg
-    - packages/shrine_images/32-0.jpg
-    - packages/shrine_images/33-0.jpg
-    - packages/shrine_images/34-0.jpg
-    - packages/shrine_images/35-0.jpg
-    - packages/shrine_images/36-0.jpg
-    - packages/shrine_images/37-0.jpg
+    - packages/shrine_images/


### PR DESCRIPTION
Instead of declaring path for each image inside the `shrine_images` folder. We can tell `pubspec.yml` file to compile and add all the images inside the `shrine_images` folder by just one line of code as implemented above.